### PR TITLE
Fix null pointer when clicking on leaf node

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -904,6 +904,9 @@ export class OrgChart {
                 const y = attrs.layoutBindings[attrs.layout].buttonY({ width, height });
                 return `translate(${x},${y})`
             })
+            .attr("display", ({ data }) => {
+                return data._directSubordinates > 0 ? null : 'none';
+            })
             .attr("opacity", ({ children, _children }) => {
                 if (children || _children) {
                     return 1;
@@ -1097,7 +1100,9 @@ export class OrgChart {
             d._children = null;
 
             // Set each children as expanded
-            d.children.forEach(({ data }) => (data._expanded = true));
+            if (d.children) {
+                d.children.forEach(({ data }) => (data._expanded = true));
+            }
         }
 
         // Redraw Graph


### PR DESCRIPTION
This resolves two issues that currently exist when a user clicks at the spot where the expand button would be on a leaf node:

1.  Prior to this change, nothing happens, whereas the expected behavior is that the node's onclick function should be called
2. Prior to this change, the below unhandled null pointer exception is thrown
![Screen Shot 2021-11-05 at 2 54 33 PM](https://user-images.githubusercontent.com/1543291/140583447-3ca5ff39-507f-4c2f-9671-a60ad1b43e14.png)
