### PR TITLE
Update d3-flextree to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "d3-hierarchy": "3",
     "d3-zoom": "3",
     "d3-shape": "3",
-    "d3-flextree": "2.1.1"
+    "d3-flextree": "2.1.2"
   }
 }


### PR DESCRIPTION
fix:
/node_modules/d3-org-chart/node_modules/d3-flextree/src/flextree.js:172:19-26 - Error: Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)

tags: webpack

related to:
https://github.com/bumbeishvili/org-chart/issues/77
https://github.com/Klortho/d3-flextree/issues/21

@bumbeishvili 