### PR TITLE
Removes spurious curly brace

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -58,7 +58,7 @@ export class OrgChart {
                        </marker>
                     `}).join("")}
                     </defs>
-                    }`},
+                    `},
             connectionsUpdate: function (d, i, arr) {
                 d3.select(this)
                     .attr("stroke", d => '#152785')


### PR DESCRIPTION
The curly wasn't doing anything and it was showing up in the source just outside the `<defs>` tag