### PR TITLE
support 'flare' type data.

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -1,6 +1,6 @@
 import { selection, select } from "d3-selection";
 import { max, min, sum, cumsum } from "d3-array";
-import { tree, stratify } from "d3-hierarchy";
+import { tree, stratify, hierarchy } from "d3-hierarchy";
 import { zoom, zoomIdentity } from "d3-zoom";
 import { flextree } from 'd3-flextree';
 import { linkHorizontal } from 'd3-shape';
@@ -14,6 +14,7 @@ const d3 = {
     cumsum,
     tree,
     stratify,
+    hierarchy,
     zoom,
     zoomIdentity,
     linkHorizontal,
@@ -42,6 +43,7 @@ export class OrgChart {
             lastTransform: { x: 0, y: 0, k: 1 },
             nodeId: d => d.nodeId || d.id,
             parentNodeId: d => d.parentNodeId || d.parentId,
+            nodeChildren: d => d.children,
             backgroundColor: 'none',
             zoomBehavior: null,
             defs: function (state, visibleConnections) {
@@ -1185,9 +1187,11 @@ export class OrgChart {
 
     setLayouts({ expandNodesFirst = true }) {
         const attrs = this.getChartState();
+
         // Store new root by converting flat data to hierarchy
-        attrs.root = d3
-            .stratify()
+        attrs.root = (attrs.data.data_type === "flare" && attrs.nodeChildren) ? 
+            d3.hierarchy(attrs.data, attrs.nodeChildren) : 
+            d3.stratify()
             .id((d) => attrs.nodeId(d))
             .parentId(d => attrs.parentNodeId(d))(attrs.data);
 

--- a/tree.html
+++ b/tree.html
@@ -139,7 +139,11 @@
             .then(dataFlattened => {
                 chart = new d3.OrgChart()
                     .container('.chart-container')
-                    .data(dataFlattened)
+                    .data({
+                        ...dataFlattened[0],
+                        data_type: "flare",
+                        children: dataFlattened.slice(1, 10)
+                    })
                     .scaleExtent([1,1])
                     // .svgHeight(window.innerHeight)
                     // .nodeWidth((d3Node) => {


### PR DESCRIPTION
Hi @bumbeishvili, sending PR to support "flare" type data, rather than only flat data. 

```
{
name: "giorgi",
data_type: "flare", // here I put data_type field to guess which hierarchy function to use. You can use different approach if you want. 
children: [],
}
```

