### PR TITLE
Add a handler for nodeEnter

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -78,6 +78,7 @@ export class OrgChart {
                     d3.select(this).raise()
                 }
             },
+            nodeEnter: function (d, i, arr) { return d },
             nodeUpdate: function (d, i, arr) {
                 d3.select(this)
                     .select('.node-rect')
@@ -819,6 +820,8 @@ export class OrgChart {
                 selector: "node-rect",
                 data: (d) => [d]
             })
+        
+        nodeEnter.each(attrs.nodeEnter);
 
         // Node update styles
         const nodeUpdate = nodeEnter


### PR DESCRIPTION
Add a handler that is invoked during nodeEnter after each node is entered into the dom. Follows the same pattern as nodeUpdate.

This creates the opportunity for a consumer to add more functionality to freshly created nodes.
e.g. add interaction for node hover.