### PR TITLE
add keydown handler to expand button

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -849,7 +849,12 @@ export class OrgChart {
                 selector: "node-button-g",
                 data: (d) => [d]
             })
-            .on("click", (event, d) => this.onButtonClick(event, d));
+            .on("click", (event, d) => this.onButtonClick(event, d))
+            .on("keydown", (event, d) => {
+                if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+                    this.onButtonClick(event, d)
+                }
+            });
 
         nodeButtonGroups.patternify({
             tag: 'rect',


### PR DESCRIPTION
This PR adds an event handler to the expands button so that when a user focuses on it and hits either the Enter or Spacebar keys the button can expand/collapse depending on the current state