### PR TITLE
Add `clear()` method to fix memory leaks

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -1582,4 +1582,10 @@ export class OrgChart {
         const measurement = ctx.measureText(text);
         return measurement.width;
     }
+
+    clear() {
+        const attrs = this.getChartState();
+        d3.select(window).on(`resize.${attrs.id}`, null);
+        attrs.svg?.selectAll("*").remove();
+    }
 }


### PR DESCRIPTION
First of all, thank you for making a nice npm library.

I added a `clear()` method to solve some problems. If there is any incorrect code, please leave a comment.


### Current behavior

Even though I navigated to a different page unrelated to it, the chart instance was not properly cleaned up.


### New behavior

Memory leaks were solved using the `clear()` method.


**Purpose of `clear()` method**
1. unsubscribe resize event
2. remove SVG elements 
  - To prevent undefined error, I used the optional chaining.


#### My use case
I use this method in `ngOnDestroy()` of Angular lifecycle for cleaning up on instance destruction.
