### PR TITLE
Customized background color for images/PDFs.

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -1419,7 +1419,7 @@ export class OrgChart {
         xhr.send();
     }
 
-    exportImg({ full = false, scale = 3, onLoad = d => d, save = true } = {}) {
+    exportImg({ full = false, scale = 3, backgroundColor = "#FAFAFA", onLoad = d => d, save = true } = {}) {
         const that = this;
         const attrs = this.getChartState();
         const { svg: svgImg, root } = attrs
@@ -1437,7 +1437,7 @@ export class OrgChart {
 
             setTimeout(d => {
                 that.downloadImage({
-                    node: svg.node(), scale, isSvg: false,
+                    node: svg.node(), scale, isSvg: false, bg,
                     onAlreadySerialized: d => {
                         that.update(root)
                     },
@@ -1487,7 +1487,7 @@ export class OrgChart {
         return this;
     }
 
-    downloadImage({ node, scale = 2, isSvg = false, save = true, onAlreadySerialized = d => { }, onLoad = d => { } }) {
+    downloadImage({ node, scale = 2, isSvg = false, save = true, backgroundColor = "#FAFAFA", onAlreadySerialized = d => { }, onLoad = d => { } }) {
         // Retrieve svg node
         const svgNode = node;
 
@@ -1514,7 +1514,7 @@ export class OrgChart {
             canvas.height = rect.height * quality;
             // Draw background
             const context = canvas.getContext('2d');
-            context.fillStyle = '#FAFAFA';
+            context.fillStyle = backgroundColor;
             context.fillRect(0, 0, rect.width * quality, rect.height * quality);
             context.drawImage(image, 0, 0, rect.width * quality, rect.height * quality);
             // Set some image metadata

--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -1437,7 +1437,7 @@ export class OrgChart {
 
             setTimeout(d => {
                 that.downloadImage({
-                    node: svg.node(), scale, isSvg: false, bg,
+                    node: svg.node(), scale, isSvg: false, backgroundColor,
                     onAlreadySerialized: d => {
                         that.update(root)
                     },


### PR DESCRIPTION
I noticed that the background fill for exported images (and PDF's) was a static #FAFAFA. I'm expecting users to print the org charts generated by my application so I wanted a completely white background.

With my code changes, you can now specify a background color like so:
`chart.exportImg({ backgroundColor: "#FFFFFF"})`

The default color, if not specified, is still #FAFAFA.

Feel free to modify as needed, I just wanted to make this minor improvement to an already great tool :)